### PR TITLE
Fixed an issue with C++ sample in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ console.log('public/ad/* should not match b2.  Actual: ', b2)
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#include <iostream>
 #include <string>
 
 using namespace std;


### PR DESCRIPTION
The first argument of `AdBlockClient::serialize()` is `int*`. In the sample code an `int` is passed instead.